### PR TITLE
Differentiate the templates according to their mode

### DIFF
--- a/src/sidebar/components/annotation.js
+++ b/src/sidebar/components/annotation.js
@@ -257,6 +257,17 @@ function AnnotationController(
   };
 
   /**
+   * @ngdoc method
+   * @name annotation.AnnotationController#isCreateModeOn.
+   * @returns {boolean} `true` if this annotation is in the create mode
+   * @returns {boolean} `false` if this annotation is in the edit mode.
+   */
+
+  this.isCreateModeOn = function(){
+    return isNew(self.annotation);
+  };
+
+  /**
     * @ngdoc method
     * @name annotation.AnnotationController#group.
     * @returns {Object} The full group object associated with the annotation.

--- a/src/sidebar/components/publish-annotation-btn.js
+++ b/src/sidebar/components/publish-annotation-btn.js
@@ -34,6 +34,7 @@ module.exports = {
     onCancel: '&',
     onSave: '&',
     onSetPrivacy: '&',
+    onCreate: '&',
   },
   template: require('../templates/publish-annotation-btn.html'),
 };

--- a/src/sidebar/templates/annotation.html
+++ b/src/sidebar/templates/annotation.html
@@ -4,6 +4,10 @@
 
 <div ng-keydown="vm.onKeydown($event)" ng-if="vm.user()">
 
+  <div class="feedback-title" ng-if="vm.editing()">
+    {{vm.isCreateModeOn() ? 'Add Feedback' : 'Edit Feedback'}}
+  </div>
+
   <!-- Excerpts -->
   <section class="annotation-quote-list"
     ng-class="{'is-orphan' : vm.isOrphan()}"
@@ -42,7 +46,7 @@
       </div>
 
     </excerpt>
-    <p ng-if="vm.editing()" style="font-size:11px;">Your feedback will be visible to other users and an issue will be opened for the documentation team.</p>
+    <p ng-if="vm.editing() && vm.isCreateModeOn()" style="font-size:11px;">Your feedback will be visible to other users and an issue will be opened for the documentation team.</p>
   </section>
 
   <!-- / Body -->
@@ -95,7 +99,9 @@
         is-shared="vm.isShared()"
         on-cancel="vm.revert()"
         on-save="vm.save()"
-        on-set-privacy="vm.setPrivacy(level)"></publish-annotation-btn>
+        on-set-privacy="vm.setPrivacy(level)"
+        on-create="vm.isCreateModeOn()"
+        ></publish-annotation-btn>
     </div>
 
     <div class="annotation-section annotation-license"

--- a/src/sidebar/templates/publish-annotation-btn.html
+++ b/src/sidebar/templates/publish-annotation-btn.html
@@ -8,13 +8,10 @@
 </button>
 <button class="btn-app btn-update"
         ng-click="vm.onSave()"
-        title="{{'Submit' | translate}}"
-        >
+        title="{{ vm.onCreate()  ? ('Submit' | translate) : ('Update' | translate)}}">
   <!-- <i class="h-icon-cancel-outline publish-annotation-cancel-btn__icon btn-icon"></i> -->
-  {{'Submit' | translate}}
+  {{ vm.onCreate()  ? ('Submit' | translate) : ('Update' | translate)}}
 </button>
-
-
 
 <!-- If the theme is not custom -->
 <div ng-if="!vm.isThemeCustom" dropdown="" class="publish-annotation-btn__btn" is-open="vm.showDropdown" keyboard-nav>


### PR DESCRIPTION
@TylerMartin5 I used "create" mode to distinguish whether it is 'add' mode or 'edit'. Let me know what you think and how this works on your side. 

Also, on annotation.html I just created a div and used a class named "feedback-title" but there is nothing inside this class. It is just a structure for you. 

